### PR TITLE
Haplo export

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: FamAgg
 Type: Package
 Title: Pedigree Analysis and Familial Aggregation
-Version: 1.5.2
+Version: 1.5.3
 Author: J. Rainer, D. Taliun, C.X. Weichenberger
 Maintainer: Johannes Rainer <johannes.rainer@eurac.edu>
 URL: https://github.com/jotsetung/FamAgg

--- a/R/import-export.R
+++ b/R/import-export.R
@@ -156,5 +156,3 @@ doImport <- function(file, ...){
     tolower(ext)
 }
 
-
-

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,12 @@
+CHANGES IN VERSION 1.5.3
+-------------------------
+
+SIGNIFICANT USER-VISIBLE CHANGES
+    o plotPed with haplopaint plotting supports device = "txt" that just writes
+      the data.frame for haplopaint and returns the file name, does however not
+      call Haplopaint.
+    
+
 CHANGES IN VERSION 1.5.2
 -------------------------
 

--- a/inst/unitTests/test_plotting.R
+++ b/inst/unitTests/test_plotting.R
@@ -88,6 +88,19 @@ test_haplopaint_txt_plot <- function() {
     res <- read.table(tmp, sep = "\t", as.is = TRUE, header = TRUE,
                       comment.char = "")
     checkEquals(as.integer(is.deceased)[fam$id %in% res$INDIVID], res$DEAD)
+    pf <- options()$FamAgg$plotfun
+    FA <- options()$FamAgg
+    FA$plotfun <- "haplopaint"
+    options(FamAgg = FA)
+    suppressWarnings(
+        tmp <- plotPed(far, family = "5", device = "txt")
+    )
+    checkTrue(is(tmp, "character"))
+    res <- read.table(tmp, sep = "\t", as.is = TRUE, header = TRUE,
+                      comment.char = "")
+    checkTrue(ncol(res) == 18)
+    FA$plotfun <- pf
+    options(FamAgg = FA)
 }
 
 notrun_test_plot <- function(){

--- a/inst/unitTests/test_plotting.R
+++ b/inst/unitTests/test_plotting.R
@@ -75,6 +75,21 @@ test_kinship2_plot <- function(){
                       is.deceased=is.deceased, dev="plot")
 }
 
+test_haplopaint_txt_plot <- function() {
+    fam <- family(far, family = "4", return.type = "data.frame")
+    is.deceased <- sample(c(TRUE, FALSE), nrow(fam), replace=TRUE)
+    suppressWarnings(
+        tmp <- FamAgg:::haplopaint(family = fam$family, individual = fam$id,
+                                   father = fam$father, mother = fam$mother,
+                                   gender = fam$sex, affected = fam$affected,
+                                   is.deceased = is.deceased, dev = "txt")
+    )
+    checkTrue(is(tmp, "character"))
+    res <- read.table(tmp, sep = "\t", as.is = TRUE, header = TRUE,
+                      comment.char = "")
+    checkEquals(as.integer(is.deceased)[fam$id %in% res$INDIVID], res$DEAD)
+}
+
 notrun_test_plot <- function(){
     ## ## again, make a simple pedigree with trait.
     ## data(minnbreast)

--- a/man/FAData.Rd
+++ b/man/FAData.Rd
@@ -552,8 +552,12 @@ FAData(pedigree, age, trait, traitName, header=FALSE, sep="\t", id.col="id",
       more information.
       Returns the file name of the file to which the pedigree plot was
       exported or \code{NULL} for \code{kinship2} plotting and
-      \code{device="plot"}. See \code{\link{doPlotPed}} for more
-      information.
+      \code{device="plot"}.
+
+      For \code{HaploPainter} plotting and \code{device = "txt"} the name
+      of the file to which the plotting data has been exported is returned.
+      
+      See \code{\link{doPlotPed}} for more information.
     }
 
   }
@@ -586,7 +590,11 @@ FAData(pedigree, age, trait, traitName, header=FALSE, sep="\t", id.col="id",
   With \code{HaploPainter}, as it is an external too, it is not possible
   to display the plot directly, but each plot is automatically saved to
   a file (either \code{"pdf"}, \code{"ps"}, \code{"svg"} or
-  \code{"png"}; can be specified with the \code{device} parameter).
+  \code{"png"}; can be specified with the \code{device}
+  parameter). \code{HaploPainter} plotting supports also \code{device =
+  "txt"} in which case the data table is exported (in the format
+  expected by \code{HaploPainter}) to a tabulator delimited text file
+  and the name of this text file is returned - no plot is created.
   Plotting with \code{kinship2} (the default) allows to display the plot
   (\code{device="plot"}) or export it to a file (\code{device="pdf"} or
   \code{device="png"}).

--- a/man/plotting-functions.Rd
+++ b/man/plotting-functions.Rd
@@ -124,10 +124,11 @@ switchPlotfun(method)
 
   \item{device}{
     The format of the output file. Can be \code{"ps"}, \code{"pdf"},
-    \code{"svg"} or \code{"png"} if \code{HaploPainter} is used to
-    create the plot, or \code{"pdf"}, \code{"png"} or \code{"plot"} if
-    \code{kinship2} is used for plotting. Note: if \code{"plot"} is specified
-    the plot is displayed instead of exported to a file.
+    \code{"svg"}, \code{"png"} or \code{"txt"} if \code{HaploPainter} is
+    used to create the plot, or \code{"pdf"}, \code{"png"} or
+    \code{"plot"} if \code{kinship2} is used for plotting. Note: if
+    \code{"plot"} is specified the plot is displayed instead of exported
+    to a file.
   }
 
   \item{res}{
@@ -177,6 +178,11 @@ switchPlotfun(method)
   or png device, while, if \code{kinship2} is used, the plot can also be
   directly plotted and displayed (if \code{device="plot"} is specified).
 
+  \code{HaploPainter} plotting supports also \code{device = "txt"} in
+  which case the pedigree data is exported (in the HaploPainter file
+  format) as a tabulator delimited file - no plot is created, the
+  name of the file is returned.
+  
   Also, the arguments of this function match the arguments for
   \code{HaploPainter} and not all settings can be directly matched to
   settings in \code{kinship2} plotting. The list below lists all


### PR DESCRIPTION
This allows to get easier hold of the haplopainter-formatted txt file (issue #13):
`device = "txt"` for haplopainter plotting returns the name of the file with the pedigree in haplopainter format.