### PR TITLE
Reduce memory footprint in simulation runs.

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -52,9 +52,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: ubuntu-latest, r: 'devel', bioc: '3.13', cont: "bioconductor/bioconductor_docker:devel", rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest" }
-          - { os: macOS-latest, r: 'devel', bioc: '3.13'}
-          - { os: windows-latest, r: '4.1', bioc: '3.13'}
+          - { os: ubuntu-latest, r: '4.1', bioc: '3.14', cont: "bioconductor/bioconductor_docker:devel", rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest" }
+          - { os: macOS-latest, r: '4.1', bioc: '3.14'}
+          - { os: windows-latest, r: '4.1', bioc: '3.14'}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: FamAgg
 Type: Package
 Title: Pedigree Analysis and Familial Aggregation
-Version: 1.19.1
+Version: 1.20.0
 Authors@R: c(person(given = "Johannes", family = "Rainer",
 	   email = "johannes.rainer@eurac.edu",
 	   role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: FamAgg
 Type: Package
 Title: Pedigree Analysis and Familial Aggregation
-Version: 1.21.0
+Version: 1.21.1
 Authors@R: c(person(given = "Johannes", family = "Rainer",
 	   email = "johannes.rainer@eurac.edu",
 	   role = c("aut", "cre"),

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,7 +1,7 @@
 ## Namespace
 import(utils)
 import(methods)
-importFrom("stats", "density")
+importFrom("stats", "density", "approxfun")
 ## import(BiocGenerics)
 ##import(igraph)
 importFrom("stats", "binom.test", "dbinom", "pbinom")

--- a/R/utils.R
+++ b/R/utils.R
@@ -267,6 +267,105 @@ sanitizePed <- function(ped){
     ped
 }
 
+## Add density from values x to a density d computed by a previous call to this
+## function. Make the initial call by omitting d.
+## Resulting density of the partitioned dataset is a (pretty decent)
+## approximation of the density obtained when submitting the whole dataset.
+inc.density <- function(x, d = NULL)
+{
+    if( is.null(d) ) {
+        ## adjust has been determined empirically.
+        dd <- density(x = x, n = 512, adjust = 0.75)
+    } else {
+        if( length(d$x)!=512 )
+            stop("Argument d has not been created by a call to this function.")
+        ## Determine the density data structure that has the larger domain and
+        ## add interpolated density values from the other data structure. By
+        ## this, the domain can grow and will never omit values that appear
+        ## later in the iterative process.
+        dd <- density(x, bw = d$bw, n = 512)
+        if( dd$x[512]<d$x[512] ) {
+            tmp <- dd; dd <- d; d <- tmp; rm(tmp)
+        }
+        delta <- dd$x[2] - dd$x[1]
+        f <- approxfun(d$x, d$y)
+        y <- f(dd$x)
+        y[is.na(y)] <- 0
+        dd$y <- dd$y + y
+        dd$y <- dd$y/(delta*sum(dd$y))
+        dd$n <- dd$n + d$n
+    }
+    dd
+}
+
+## Add histogram from values x to a histogram h computed by a previous call to
+## this function. Additionally, reports the number of values that produced an
+## overflow in variable nreplace (i.e. values did were too large to be included
+## in any bin of the histogram h). Make the initial call by omitting h.
+##
+## Resulting histogram of the partitioned dataset is a (pretty decent)
+## approximation of the histogram obtained when submitting the whole dataset.
+## Drawback: the domain of the histogram cannot be changed during addition of
+## new values. We therefore rely on the first batch as a random sample of the
+## population and estimate the overall domain.
+inc.hist <- function(x, h = NULL)
+{
+    if( is.null(h) ) {
+        ## Empirically determined overall size of the domain (110%).
+        hh <- hist(x, breaks = 1/127*(0:127)*max(x)*1.1, plot = FALSE)
+        hh$nreplace <- 0
+    } else {
+        if( is.null(h$nreplace) )
+            stop("Argument h has not been created by a call to this function.")
+        maxv <- h$breaks[length(h$breaks)]
+        nreplace <- sum(x>maxv)
+        if( nreplace>0 )
+            x[x>maxv] <- maxv
+        hh <- hist(x, breaks = h$breaks, plot = FALSE)
+        hh$counts <- hh$counts + h$counts
+        hh$density <- (hh$counts/sum(hh$counts))/diff(hh$breaks)
+        hh$nreplace <- h$nreplace + nreplace
+    }
+    hh
+}
+
+## Add tabulated data from values x to a table t computed by a previous call to
+## this function. Make the initial call by omitting t.
+## This function produces identical results when used in the iterative way
+## compared to submitting the whole dataset at once.
+inc.table <- function(x, t = NULL)
+{
+    if( is.null(t) ) {
+        tt <- table(x)
+    } else {
+        tt <- table(x)
+        both <- intersect(names(t), names(tt))
+        tt[both] <- tt[both] + t[both]
+        tonly <- setdiff(names(t), names(tt))
+        tt[tonly] <- t[tonly]
+    }
+    tt
+}
+
+## Convert 1D count table with only integers as counted objects to a histogram.
+table2hist.int <- function(t)
+{
+    ## Only 1D tables have names(), for higher dimensional tables, it is set to
+    ## NULL. dimnames() OTH works opposite.
+    nms <- names(t)
+    stopifnot("Table must be one-dimensional" = length(nms)>=1)
+    suppressWarnings( bins <- as.integer(names(t)) )
+    stopifnot("Table can be integer only." = all(as.character(bins)==nms))
+    h <- list(breaks = c(bins, max(bins) + 1),
+              counts = as.vector(t),
+              mids = bins + 0.5,
+              xname = "generic",
+              equidist = TRUE)
+    attr(h, "class") <- "histogram"
+    h
+}
+
+
 #' find the subPedigree (smallest pedigree) including the individuals specified
 #' with id and all eventually needed additionals
 #'

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,4 +1,4 @@
-CHANGES in VERSION 1.20.0
+CHANGES in VERSION 1.21.1
 -------------------------
 
 o Keep memory consumption constant. This allows arbitrary long simulation

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,13 @@
+CHANGES in VERSION 1.20.0
+-------------------------
+
+o Keep memory consumption constant. This allows arbitrary long simulation
+  runs without running out of memory. Fixes issue #22. Due to the solution
+  of that problem, histograms and densities reported by the simulation
+  functions may slightly deviate from comparable former runs on the same
+  data.
+
+
 CHANGES in VERSION 1.19.1
 -------------------------
 


### PR DESCRIPTION
A complete simulation run is broken down into manageable chunks of simulations, 1000 at the moment. Data obtained in this way are added incrementally to dedicated data structures. Histograms and densities in the result objects are affected by this change, and will appear slightly different. This fixes issue #22. Needless to say that `R CMD check` finishes without complaints.

Tests corrected: Kinship sum test, Kinship group test.

Test not corrected: Familial incidence rate test.

Test not affected by this issue: Genealogical index of familiality test.

I have repeated the familial aggregation runs presented in the memory consumption table in issue #22. For documentation purposes, these runs are command line calls using the Institute for Biomedicine (EURAC) internal Gitlab `chris-famagg` package,

    maxmem time /home/shared/bioinf/R/bin/Rscript-4.0-BioC3.12 src/R/famaggize.R --skipkin --trait bu02-up-x0lp17 --method ks --plotter ks2paint --pedformat png --dataset c13000 --nsim N

where `N` is the number of simulation runs given in the following table:

_N_ | Time (s) | Max. mem (KB)| Time (s, fix)| Max. mem (KB, fix)
---------:|---------:|-------------:|------------:|-------------------:
1,000 |      61  |     642,848  |          68 |           593,224
2,000 |      92  |     564,812  |         102 |           594,156
4,000 |     132  |     619,124  |         138 |           625,572
8,000 |     236  |     731,824  |         255 |           656,464
16,000 |     437  |     900,644  |         463 |           585,188
32,000 |     799  |   1,368,572  |         725 |           645,312
64,000 |   1,400  |   2,558,352  |       1,553 |           610,064
128,000 |   3,088  |   5,054,656  |       3,001 |           624,660
256,000 |   5,794  |   8,911,296  |       6,109 |           647,648
512,000 |  12,445  |  15,579,764  |      11,814 |           638,508
1,024,000 |  24,803  |  34,090,076  |          NA |                NA

The first three columns are as in issue #22, the last two columns contain values measured with the memory fix presented here. Runtime is barely affected, the fluctuations are due to the workload of the time of the experiment. It appears there is a bit of an overhead introduced, expressed in runtime increments below 11% with a remarkable outlier for _N_ = 512,000 (-6%). We have refrained from running a million simulations, simply because the trend is so evident and to save time, resources, energy, and the planet.