### PR TITLE
Mark kins in KS test result output

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -54,7 +54,7 @@ jobs:
         config:
           - { os: ubuntu-latest, r: '4.1', bioc: '3.14', cont: "bioconductor/bioconductor_docker:devel", rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest" }
           - { os: macOS-latest, r: '4.1', bioc: '3.14'}
-          - { os: windows-latest, r: '4.1', bioc: '3.14'}
+          - { os: windows-latest, r: '4.1', bioc: '3.13'}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: FamAgg
 Type: Package
 Title: Pedigree Analysis and Familial Aggregation
-Version: 1.19.1
+Version: 1.20.0
 Authors@R: c(person(given = "Johannes", family = "Rainer",
 	   email = "johannes.rainer@eurac.edu",
 	   role = c("aut", "cre"),

--- a/R/Methods-FAData.R
+++ b/R/Methods-FAData.R
@@ -1027,10 +1027,10 @@ setMethod("getSiblings", "FAData",
           })
 
 setMethod("shareKinship", "FAData",
-          function(object, id=NULL){
+          function(object, id=NULL, rmKinship=0){
               if(is.null(id))
                   stop("id has to be specified!")
-              doShareKinship(kin=kinship(object), id=id)
+              doShareKinship(kin=kinship(object), id=id, rmKinship=rmKinship)
           })
 
 setMethod("getCommonAncestor", "FAData",

--- a/R/Methods-FAKinGroupResults.R
+++ b/R/Methods-FAKinGroupResults.R
@@ -429,7 +429,8 @@ setMethod("buildPed", "FAKinGroupResults",
           })
 
 ## this is to get all those that are related with any individuals of the group!!!
-setMethod("shareKinship", "FAKinGroupResults", function(object, id = NULL) {
+setMethod("shareKinship", "FAKinGroupResults",
+          function(object, id = NULL, rmKinship = 0) {
     if (is.null(id))
         stop("The id of the group has to be speficied!")
     affGroup <- affectedKinshipGroups(object)
@@ -439,7 +440,7 @@ setMethod("shareKinship", "FAKinGroupResults", function(object, id = NULL) {
     affGroup <- affGroup[[id]]
     allids <- unique(c(affGroup$aff, affGroup$pheno))
     ## get all individuals of the group...
-    doShareKinship(kin=kinship(object), id=allids)
+    doShareKinship(kin=kinship(object), id=allids, rmKinship=rmKinship)
 })
 
 ## plot the pedigree for the kinship group...

--- a/R/Methods-FAKinSumResults.R
+++ b/R/Methods-FAKinSumResults.R
@@ -105,7 +105,8 @@ setMethod("runSimulation", "FAKinSumResults",
           })
 
 ## results; get the results table.
-setMethod("result", "FAKinSumResults", function(object, method="BH"){
+setMethod("result", "FAKinSumResults",
+          function(object, method="BH", cutoff=0.05){
     method <- match.arg(method, p.adjust.methods)
     TraitName <- object@traitname
     if(length(TraitName)==0)
@@ -119,6 +120,7 @@ setMethod("result", "FAKinSumResults", function(object, method="BH"){
             affected_id = NA,
             family = NA,
             affected = NA,
+            ksgrp = NA,
             kinship_sum = NA,
             freq = NA,
             pvalue = NA,
@@ -147,16 +149,45 @@ setMethod("result", "FAKinSumResults", function(object, method="BH"){
         affected_id=affIds,
         family=fams,
         affected=rep(length(resList$affected), length(resList$sumKinship)),
+        ksgrp=NA,
         kinship_sum=resList$sumKinship,
         freq=resList$frequencyKinship,
         pvalue=resList$pvalueKinship,
         padj=p.adjust(resList$pvalueKinship, method=method),
         stringsAsFactors=FALSE)
     rownames(res) <- as.character(res$affected_id)
-    return(res[order(res$pvalue, -res$kinship_sum), , drop=FALSE])
+    res <- res[order(res$pvalue, -res$kinship_sum), , drop=FALSE]
+    padj <- res$padj
+    names(padj) <- rownames(res)
+    res$ksgrp <- define.result.groups.ks(kinship(object), padj, th=cutoff)
+    return(res)
 })
 
-
+##' Define groups of related affected individuals for KS test.
+##' @param kin Kinship matrix.
+##' @param padj Named vector with adjusted P values of all affected individuals.
+##' @param th  Threshold of `padj` for inclusion of affected individuals.
+##' @return A named vector of group numbers or NAs, the names correspond to the
+##' IDs of the affected individuals. An NA indicates that the affected
+##' individual was above the threshold. The named vector corresponds to the
+##' entries in vector `padj`.
+define.result.groups.ks <- function(kin, padj, th=0.05)
+{
+    stopifnot("Vector padj must have associated names."=!is.null(names(padj)))
+    allIDs <- names(padj)
+    thIDs <- allIDs[padj<th]
+    grpNr  <- 1
+    grp    <- rep(NA, length(allIDs))
+    names(grp) <- allIDs
+    while( length(thIDs)>0 ) {
+        kinIDs <- intersect(doShareKinship(kin=kin, id=thIDs[1]), allIDs)
+        ## Don't overwrite previously assigned group numbers.
+        grp[is.na(grp) & names(grp) %in% kinIDs] <- grpNr
+        grpNr <- grpNr + 1
+        thIDs <- setdiff(thIDs, kinIDs)
+    }
+    grp
+}
 
 ## null hypothesis. H0: sum of kinship values of affected
 ## with all other affected is random. Test: is the sum of kinship values of

--- a/R/utils.R
+++ b/R/utils.R
@@ -164,7 +164,10 @@ df2ped <- function(ped){
 ## finds related individuals, i.e. individuals sharing the same blood line.
 ## should we call this "shareBloodLine" or "shareKinship"
 ## ped has to be the data.frame that we get with the pedigree method.
-doShareKinship <- function(ped, kin, id){
+## Use `rmKinship` for fine control: omit all individuals with kinship less
+## than or equal to this paramter. Since it defaults to 0, all individuals
+## sharing blood line will be reported by default.
+doShareKinship <- function(ped, kin, id, rmKinship=0){
     if(missing(ped) & missing(kin))
         stop("ped or kin has to be submitted!")
     if(missing(id))
@@ -179,7 +182,7 @@ doShareKinship <- function(ped, kin, id){
         stop("id has to be present in ped or kin!")
     ## subset to id (which can be more than one)
     kin <- kin[id, , drop=FALSE]
-    related <- colnames(kin)[colSums(kin) > 0]
+    related <- colnames(kin)[colSums(kin>rmKinship)>0]
     related
 }
 

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,9 @@
+CHANGES in VERSION 1.20.0
+-------------------------
+
+o Add information on kinship-based relatedness to kinship sum test results.
+
+
 CHANGES in VERSION 1.19.1
 -------------------------
 

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,6 +1,7 @@
 CHANGES in VERSION 1.21.1
 -------------------------
 
+o Add information on kinship-based relatedness to kinship sum test results.
 o Keep memory consumption constant. This allows arbitrary long simulation
   runs without running out of memory. Fixes issue #22. Due to the solution
   of that problem, histograms and densities reported by the simulation

--- a/man/FAKinGroupResults.Rd
+++ b/man/FAKinGroupResults.Rd
@@ -56,7 +56,7 @@
 
 \S4method{runSimulation}{FAKinGroupResults}(object, nsim=50000, strata=NULL)
 
-\S4method{shareKinship}{FAKinGroupResults}(object, id=NULL)
+\S4method{shareKinship}{FAKinGroupResults}(object, id=NULL, rmKinship=0)
 
 \S4method{trait}{FAKinGroupResults}(object) <- value
 
@@ -126,6 +126,12 @@
     pedigree containing only individuals in the kinship group
     (\code{prune=TRUE}); see details for more information. Note: the
     \code{plotPed} method does also support this parameter.
+  }
+
+  \item{rmKinship}{
+    For \code{shareKinship}: Restrict reporting pairs to those that have
+    kinship values >\code{rmKinship}. See \code{shareKinship} below for more
+    details.
   }
 
   \item{strata}{
@@ -284,7 +290,14 @@
     \item{shareKinship}{
       Returns a character vector with ids of all individuals that share
       kinship with any of the individuals in the kinship group
-      identified by the argument \code{id}.
+      identified by the argument \code{id}. If \code{rmKinship} is
+      specified, only individuals with a kinship >\code{rmKinship}
+      to the group defined by \code{id} will be reported. This esentially
+      restricts only the inclusion of individuals outside of the group.
+      Everyone inside the group will be reported independently of the
+      threshold defined by \code{rmKinship}. This feature has mainly been
+      implemented for reasons of API compatibility with the remaining
+      versions of \code{shareKinship}.
     }
 
     \item{trait<-}{

--- a/man/FAKinSumResults.Rd
+++ b/man/FAKinSumResults.Rd
@@ -41,7 +41,7 @@
 \S4method{plotRes}{FAKinSumResults}(object, id=NULL, family=NULL,
                                      addLegend=TRUE, type="density", ...)
 
-\S4method{result}{FAKinSumResults}(object, method="BH")
+\S4method{result}{FAKinSumResults}(object, method="BH", cutoff=0.05)
 
 \S4method{runSimulation}{FAKinSumResults}(object, nsim=50000,
 strata=NULL, ...)
@@ -55,6 +55,16 @@ strata=NULL, ...)
 
   \item{addLegend}{
     For \code{plotRes}: if a legend should be added to the plot.
+  }
+
+  \item{cutoff}{
+    For \code{result}: P-value cutoff for clustering of kinship-related
+    affected individuals based on their \code{padj} value. Individuals with
+    p-value lower than this cutoff will be included in the grouping. Each group
+    will have at least one individual that satisfies this threshold, as this is
+    the one that started that group. Others are included due to kinship to this
+    particular individual. This is especially useful for large pedigrees with
+    inaccurate or missing family assignment.
   }
 
   \item{device}{
@@ -176,6 +186,10 @@ strata=NULL, ...)
       \code{"affected_id"}: the id of the affected individual for whom
       the test has been performed.
       \code{"family"}: the family id of the affected.
+      \code{"ksgrp"}: Numeric identifier that specifies a group of affected
+      individuals related by kinship. Group assignment starts with the top
+      ranking individual, \code{NA} is assigned to those that did not pass
+      the threshold \code{cutoff} supplied to \code{result}.
       \code{"kinship_sum"}: the sum of kinship values.
       \code{"freq"}: the expected frequency of the kinship sum from the
       simulation.

--- a/man/FAKinSumResults.Rd
+++ b/man/FAKinSumResults.Rd
@@ -41,7 +41,7 @@
 \S4method{plotRes}{FAKinSumResults}(object, id=NULL, family=NULL,
                                      addLegend=TRUE, type="density", ...)
 
-\S4method{result}{FAKinSumResults}(object, method="BH", cutoff=0.05)
+\S4method{result}{FAKinSumResults}(object, method="BH", cutoff=0.05, rmKinship=0)
 
 \S4method{runSimulation}{FAKinSumResults}(object, nsim=50000,
 strata=NULL, ...)
@@ -108,6 +108,11 @@ strata=NULL, ...)
     trait information). If \code{TRUE}, the function removes all
     non-phenotyped individuals, keeping only those that are required for
     the pedigree to be complete.
+  }
+
+  \item{rmKinship}{
+    For \code{result}: When assigning kinship groups, skip pairs of cases
+    with kinship <= \code{rmKinship}.
   }
 
   \item{strata}{
@@ -188,8 +193,13 @@ strata=NULL, ...)
       \code{"family"}: the family id of the affected.
       \code{"ksgrp"}: Numeric identifier that specifies a group of affected
       individuals related by kinship. Group assignment starts with the top
-      ranking individual, \code{NA} is assigned to those that did not pass
-      the threshold \code{cutoff} supplied to \code{result}.
+      ranking individual (by \code{padj}), \code{NA} is assigned to those
+      that did not pass the threshold \code{cutoff} supplied to \code{result}.
+      If parameter \code{rmKinship} is passed, assignment is restricted to
+      kinship values >\code{rmKinship} between the top ranking individual
+      that founded this group and the rest. Kinship-related individuals that
+      have a lower kinship value will be left unassigned, therefore they may
+      end up in a separate group.
       \code{"kinship_sum"}: the sum of kinship values.
       \code{"freq"}: the expected frequency of the kinship sum from the
       simulation.

--- a/man/Pedigree-utils.Rd
+++ b/man/Pedigree-utils.Rd
@@ -120,7 +120,7 @@ ped2graph(ped)
 
 subPedigree(ped, id=NULL, all=TRUE)
 
-\S4method{shareKinship}{FAData}(object, id)
+\S4method{shareKinship}{FAData}(object, id, rmKinship=0)
 
 }
 \arguments{
@@ -209,6 +209,12 @@ subPedigree(ped, id=NULL, all=TRUE)
     the pedigree. If a \code{data.frame} is submitted, the columns
     \code{id}, \code{family}, \code{father}, \code{mother} and
     \code{sex} are required.
+  }
+
+  \item{rmKinship}{
+    For \code{shareKinship}: threshold for inclusion in being reported.
+    Pairs of individuals with a kinship less or equal than this value
+    will be omitted. This can be used to remove very distant relatives.
   }
 
   \item{...}{
@@ -333,9 +339,10 @@ subPedigree(ped, id=NULL, all=TRUE)
     }
 
     \item{shareKinship}{
-      Finds all related individuals (individuals sharing kinship with
-      the individual) for the specified individual(s) in the pedigree
-      and returns their ids as a character vector.
+      Finds all related individuals (individuals sharing kinship >
+      \code{rmKinship} with the individual) for the specified
+      individual(s) in the pedigree and returns their ids as a character
+      vector.
     }
   }
 }

--- a/vignettes/FamAgg.Rmd
+++ b/vignettes/FamAgg.Rmd
@@ -312,6 +312,18 @@ identify all individuals in the pedigree that share kinship with individual `4`.
 shareKinship(fad, id = "4")
 ```
 
+It is also possible to prune remote relatives. If we don't want to include grand
+children, (first) cousins and everbody else more remotely related to individual
+`4`, we use the option `rmKinship`. Essentially, only siblings, children, and
+parents remain.
+
+```{r  shareKinshipRm, message = FALSE }
+## Get all individuals sharing kinship with individual 4, but only with kinship
+## higher than 0.125 (exclude first cousins, grand children, great grand
+## parents etc, i.e. everybody with kinship 0.125 or lower)
+shareKinship(fad, id = "4", rmKinship = 0.125)
+```
+
 Next, we determine generations within the pedigree. Generations can only be
 estimated for a single family, since in most instances e.g. the year of birth is
 not available. Thus, generations are estimated considering the relation between

--- a/vignettes/FamAgg.Rmd
+++ b/vignettes/FamAgg.Rmd
@@ -24,7 +24,7 @@ references:
 ```{r  echo = FALSE, results = "hide" }
 isWindows <- .Platform$OS.type != "unix"
 library(FamAgg)
-library(BiocStyle) 
+library(BiocStyle)
 ```
 
 **Package**: `r BiocStyle::Biocpkg("FamAgg")`<br />
@@ -75,7 +75,7 @@ colnames(mbped) <- c("family", "id", "father", "mother", "sex")
 endage <- mbsub$endage
 names(endage) <- mbsub$id
 ## Create the object.
-fad <- FAData(pedigree = mbped, age = endage) 
+fad <- FAData(pedigree = mbped, age = endage)
 ```
 
 We can access all the pedigree information stored in this object using the
@@ -98,7 +98,7 @@ head(fad$sex)
 
 ## We can also access the age of each individual, if
 ## provided.
-head(age(fad)) 
+head(age(fad))
 ```
 
 To extract the pedigree for a single family we can use the `family` method,
@@ -116,7 +116,7 @@ head(family(fad, id = 3))
 
 ## Note that IDs are internally always converted to character,
 ## thus, using id=3 and id="3" return the same information.
-head(family(fad, id = "3")) 
+head(family(fad, id = "3"))
 ```
 
 Alternatively, we could subset the `FAData` to individuals of a single family.
@@ -124,7 +124,7 @@ Alternatively, we could subset the `FAData` to individuals of a single family.
 ```{r  subsetting }
 ## Subset the object to a single family.
 fam4 <- fad[fad$family == "4", ]
-table(fam4$family) 
+table(fam4$family)
 ```
 
 To explore this family we can plot its pedigree. By default, the plotting
@@ -146,7 +146,7 @@ individual's ID.
 switchPlotfun("ks2paint")
 ## By supplying device="plot", we specify that we wish to visualize the
 ## pedigree in an R plot. This is the default for "ks2paint", anyway.
-plotPed(fad, id = 3, device = "plot") 
+plotPed(fad, id = 3, device = "plot")
 ```
 
 The pedigree for an individual or a list of individuals can be extracted using
@@ -157,7 +157,7 @@ individuals and all identified parents.
 ```{r  buildPed, message = FALSE }
 ## Build the pedigree for individual 3.
 fullPed <- buildPed(fad, id = "3")
-nrow(fullPed) 
+nrow(fullPed)
 ```
 
 Alternatively, we can extract the smallest possible pedigree for a list of
@@ -168,13 +168,13 @@ between them.
 
 ```{r  buildPed-prune, message = FALSE }
 ## Find the subpedigree for individuals 21, 22 and 17.
-buildPed(fad, id = c(21, 22, 17), prune = TRUE) 
+buildPed(fad, id = c(21, 22, 17), prune = TRUE)
 ```
 
 And the pedigree plot for that subset of the whole family:
 
 ```{r  plotPed-3ids, message=FALSE, fig.align='center', warning = FALSE }
-plotPed(fad, id = c(21, 22, 17), prune = TRUE) 
+plotPed(fad, id = c(21, 22, 17), prune = TRUE)
 ```
 
 Note that the pedigree returned by the `buildPed` method for an individual might
@@ -187,7 +187,7 @@ plot&#x2026;" is issued by the `kinship2` plotting function and indicates single
 that are assigned to the family but do neither have parents nor children.)
 
 ```{r  plotPed-family-14, message=FALSE, fig.align='center', warning = FALSE }
-plotPed(fad, family = "14", cex = 0.4) 
+plotPed(fad, family = "14", cex = 0.4)
 ```
 
 In this family, founder `441` is the founder of two family branches. Building
@@ -202,7 +202,7 @@ she shares kinship with them (*via* her mother `441`).
 any(buildPed(fad, id = "440")$id == "26064")
 
 ## What for the pedigree of 447?
-any(buildPed(fad, id = "447")$id == "26064") 
+any(buildPed(fad, id = "447")$id == "26064")
 ```
 
 A family pedigree may consist of many founder couples (i.e. individuals for
@@ -214,7 +214,7 @@ couples in the family pedigree with the same number of offspring generations.
 
 ```{r  findFounders, message = FALSE }
 ## Find founders for family 4.
-findFounders(fad, "4") 
+findFounders(fad, "4")
 ```
 
 Alternatively, it might be of interest to determine the closest common ancestor
@@ -224,7 +224,7 @@ know from the pedigree a bit above are `1` and `2`).
 
 ```{r  getCommonAncestors, message = FALSE }
 ## Find the closest common ancestor.
-getCommonAncestor(fad, id = c(21, 22, 17)) 
+getCommonAncestor(fad, id = c(21, 22, 17))
 ```
 
 Other useful methods are `getChildren`, `getAncestors` and `getSiblings`, that
@@ -243,7 +243,7 @@ getChildren(fad, id = "4")
 getAncestors(fad, id = "4")
 
 ## Get the siblings.
-getSiblings(fad, id = c("4")) 
+getSiblings(fad, id = c("4"))
 ```
 
 In the whole Minnesota Breast Cancer data set there are 426 families
@@ -280,7 +280,7 @@ length(founders)
 
 ## The number of families with affected founder.
 length(affFounders)
- 
+
 ```
 
 Unexpectedly, only in few families one of the founders is affected. For the
@@ -298,7 +298,7 @@ sum(kin2affFounders %in% affIds)
 
 ## How many affected are not related to an affected founder?
 sum(!(affIds %in% kin2affFounders))
- 
+
 ```
 
 
@@ -309,7 +309,7 @@ identify all individuals in the pedigree that share kinship with individual `4`.
 
 ```{r  shareKinship, message = FALSE }
 ## Get all individuals sharing kinship with individual 4.
-shareKinship(fad, id = "4") 
+shareKinship(fad, id = "4")
 ```
 
 Next, we determine generations within the pedigree. Generations can only be
@@ -325,7 +325,7 @@ names corresponding to the ID of the respective individual).
 
 ```{r  estimageGenerations, message = FALSE }
 ## Estimate generation levels for all families.
-estimateGenerations(fad)[1:3] 
+estimateGenerations(fad)[1:3]
 ```
 
 Individuals without generation level (i.e. with an `NA`) are not connected to
@@ -336,13 +336,13 @@ In addition, it is also possible to calculate generation levels relative to a
 (single) specified individual:
 
 ```{r  generationsFrom, message = FALSE }
-gens <- generationsFrom(fad, id = "4") 
+gens <- generationsFrom(fad, id = "4")
 ```
 
 We can render these generation numbers into the pedigree:
 
 ```{r  plotPed-with-generations, message=FALSE, fig.align='center', warning = FALSE }
-plotPed(fad, family = 4, label2 = gens) 
+plotPed(fad, family = 4, label2 = gens)
 ```
 
 
@@ -360,7 +360,7 @@ tcancer <- mbsub$cancer
 names(tcancer) <- mbsub$id
 ## Set the trait.
 trait(fad) <- tcancer
- 
+
 ```
 
 We can now extract the trait information from the object or identify directly
@@ -374,7 +374,7 @@ head(trait(fad))
 head(affectedIndividuals(fad))
 
 ## Or the IDs of the phenotyped individuals.
-head(phenotypedIndividuals(fad)) 
+head(phenotypedIndividuals(fad))
 ```
 
 Plotting a `FAData` object with trait information results in a pedigree plot
@@ -384,7 +384,7 @@ symbols and symbols with a question mark inside, respectively).
 
 ```{r  plotPed-with-trait, message=FALSE, fig.align='center', warning = FALSE }
 ## Plotting the pedigree for family "9".
-plotPed(fad, family = "9") 
+plotPed(fad, family = "9")
 ```
 
 In addition, we can manually highlight individuals using the `highlight.ids`
@@ -395,7 +395,7 @@ corner of the symbol and the second element on the top right corner.
 ```{r  plotPed-trait-highlight, message=FALSE, fig.align='center', warning = FALSE }
 ## Plotting the pedigree for family "9".
 plotPed(fad, family = "9", highlight.ids = list(a = c("185", "201", "198"),
-						b = c("193"))) 
+						b = c("193")))
 ```
 
 An alternative way to highlight individuals or add text to the plot is to use
@@ -413,7 +413,7 @@ applied to pedigrees.
 fullGraph <- ped2graph(pedigree(fad))
 
 ## In addition, build the graph for a single family.
-singleFam <- ped2graph(family(fad, family=4)) 
+singleFam <- ped2graph(family(fad, family=4))
 ```
 
 We can plot these pedigrees also as graph and could use any of the layout
@@ -423,7 +423,7 @@ methods provided in the `igraph` package.
 ## Build the layout.
 plot(fullGraph)
 lay <- layout_(singleFam, on_grid())
-plot(singleFam, layout = lay) 
+plot(singleFam, layout = lay)
 ```
 
 The `connectedSubgraph` function implemented in the `FamAgg` package provides
@@ -434,7 +434,7 @@ In the code below we want to extract the smallest possible connected subgraph of
 the pedigree-graph of family 4 containing individuals `7`, `8`, `27` and `17`.
 
 ```{r  connectedSubgraph, message = FALSE }
-subgr <- connectedSubgraph(singleFam, nodes = c("7", "8", "27", "17")) 
+subgr <- connectedSubgraph(singleFam, nodes = c("7", "8", "27", "17"))
 ```
 
 This is in principle what the `buildPed` method with the option `prune=TRUE`
@@ -445,7 +445,7 @@ does to find the smallest pedigree for a set of individuals, only that
 ## Plot the graph.
 plot(subgr)
 ## Similar to buildPed/plotPed with prune=TRUE.
-plotPed(fad, id=c("7", "8", "17", "27"), prune=TRUE) 
+plotPed(fad, id=c("7", "8", "17", "27"), prune=TRUE)
 ```
 
 
@@ -464,7 +464,7 @@ readLines(pedFile, n = 1)
 fad <- FAData(pedFile)
 
 head(pedigree(fad))
- 
+
 ```
 
 Alternatively, we can import pedigree data from generic input files.
@@ -475,7 +475,7 @@ pedFile <- system.file("txt/minnbreastsub.txt", package = "FamAgg")
 fad <- FAData(pedigree = pedFile, header = TRUE, id.col = "id",
 	      family.col = "famid", father.col = "fatherid",
 	      mother.col = "motherid")
- 
+
 ```
 
 And we can export pedigree data again using the `export` method. In the example
@@ -489,7 +489,7 @@ tmpF <- tempfile()
 fam4 <- fad[fad$family == 4, ]
 
 ## Export data in ped format.
-export(fam4, tmpF, format = "ped") 
+export(fam4, tmpF, format = "ped")
 ```
 
 
@@ -539,7 +539,7 @@ fad <- FAData(pedigree = mbped)
 
 ## Define the trait.
 tcancer <- mbsub$cancer
-names(tcancer) <- as.character(mbsub$id) 
+names(tcancer) <- as.character(mbsub$id)
 ```
 
 In the following section we analyze the data set first using the *genealogical
@@ -584,7 +584,7 @@ gi <- genealogicalIndexTest(fad, trait = tcancer,
 			    traitName = "cancer", nsim = nsim)
 
 ## Display the result.
-result(gi) 
+result(gi)
 ```
 
 The column *genealogical index* of the result `data.frame` shown above represents
@@ -627,7 +627,7 @@ giSexMatch <- genealogicalIndexTest(fad, trait = tcancer,
 giExtMatch <- genealogicalIndexTest(fad, trait = tcancer,
 				    traitName = "cancer", nsim = nsim,
 				    controlSetMethod = "getExternalMatched",
-				    match.using = fad$sex) 
+				    match.using = fad$sex)
 ```
 
 Note that any matching or stratified sampling can lead to the exclusion of
@@ -649,7 +649,7 @@ giStrata <- genealogicalIndexTest(fad, trait = tcancer,
 				  traitName = "cancer", nsim = nsim,
 				  strata = fad$sex)
 
-result(giStrata) 
+result(giStrata)
 ```
 
 Finally, we plot the result from the simulation. The blue vertical line in the
@@ -659,7 +659,7 @@ drawn sets are shown in grey color.
 
 ```{r  gif-4-plot, mbreast-genealogical-index-result, message=FALSE, warning=FALSE, fig.align='center' }
 ## Plot the result.
-plotRes(giStrata) 
+plotRes(giStrata)
 ```
 
 The genealogical index of familiality can also be estimated by the `gif`
@@ -692,7 +692,7 @@ gifRes <- gif(pedi[, c("id", "father", "mother")], affIds)
 gifT <- genealogicalIndexTest(fad, trait = tcancer, nsim = 100)
 
 ## Comparing the results:
-gifRes[[1]] == result(gifT)$genealogical_index 
+all.equal( result(gifT)$genealogical_index,  gifRes[[1]] )
 ```
 
 Thus, the GIF estimate from the `gap` package is identical to the one from the
@@ -711,7 +711,7 @@ giFam <- genealogicalIndexTest(fad, trait = tcancer, nsim = nsim,
 			       traitName = "Cancer")
 
 ## Display the result from the analysis.
-head(result(giFam)) 
+head(result(giFam))
 ```
 
 
@@ -737,7 +737,7 @@ details and options related to *time at risk*.
 ## rate method. We use the "endage" provided in the Minnesota Breast Cancer
 ## Record as a measure for time at risk.
 fr <- familialIncidenceRate(fad, trait = tcancer, timeAtRisk = mbsub$endage)
- 
+
 ```
 
 A note on singletons: for all per-individual measures unconnected individuals
@@ -762,7 +762,7 @@ frFamAvg <- sort(unlist(frFamAvg), decreasing = TRUE)
 plot(frFamAvg, type = "h", xaxt = "n", xlab = "", ylab = "mean FIR",
      main = "Per family averaged familial incidence rate")
 axis(side = 1, las = 2, at = 1:length(frFamAvg), label = names(frFamAvg))
- 
+
 ```
 
 Not unexpectedly, individuals in some families have on average a higher familial
@@ -781,7 +781,7 @@ frTest <- familialIncidenceRateTest(fad, trait = tcancer,
 				    traitName = "cancer",
 				    timeAtRisk = mbsub$endage,
 				    nsim = nsim)
- 
+
 ```
 
 The familial incidence rate can be extracted easily from the result object using
@@ -792,14 +792,14 @@ operator (i.e. using `$pvalue`, `$tar` or `$timeAtRisk`, respectively).
 ```{r  fir-4 }
 head(familialIncidenceRate(frTest))
 head(frTest$fir)
- 
+
 ```
 
 Finally, we inspect the results from the analysis.
 
 ```{r  fir-5 }
 head(result(frTest))
- 
+
 ```
 
 We can also identify the families containing individuals with a significant FIR.
@@ -823,7 +823,7 @@ frRes <- cbind(frRes, t(noPheNAff))
 
 ## Display the number of phenotyped and affected individuals as well as
 ## the number of individuals within the families with a significant FIR.
-frRes[order(frRes[, "no_sign_fir"], decreasing = TRUE), ] 
+frRes[order(frRes[, "no_sign_fir"], decreasing = TRUE), ]
 ```
 
 We have an enrichment of affected cases in families 173, 13 and 432.
@@ -844,7 +844,7 @@ proportions in the *real*, observed, affected.
 kinSum <- kinshipSumTest(fad, trait = tcancer, traitName = "cancer",
 			 nsim = nsim, strata = fad$sex)
 head(result(kinSum))
- 
+
 ```
 
 Next, we identify those individuals that have a significant kinship sum
@@ -858,7 +858,7 @@ kinSumRes <- result(kinSum)
 kinSumIds <- as.character(kinSumRes[kinSumRes$padj < 0.1, "affected_id"])
 
 ## From which families are these?
-table(kinSumRes[kinSumIds, "family"]) 
+table(kinSumRes[kinSumIds, "family"])
 ```
 
 Thus, most of the identified significant individuals are from two families.
@@ -884,7 +884,7 @@ strat[kinSum$id %in% fam$id[which(fam$affected > 0)]] <-
 famData <- data.frame(fr = fr, group = strat)
 boxplot(fr~group, data = famData, na.rm = TRUE, ylab = "FIR",
 	col = rep(c("#FBB4AE", "#B3CDE3"), 2))
- 
+
 ```
 
 As expected, the familial incidence rate (i.e., in the present data set, the
@@ -899,7 +899,7 @@ Next, we plot the pedigree of this family.
 ## all individuals that were not phenotypes.
 plotPed(kinSum, id = kinSumIds[1], cex = 0.3, only.phenotyped = TRUE)
 
- 
+
 ```
 
 And finally, also plot the kinship sum for the individuals with the largest
@@ -907,7 +907,7 @@ kinship sum in relation to the *expected* kinship sums from the Monte Carlo
 simulations.
 
 ```{r  kinsum-5, mbreast-family-432-affecte-res, message=FALSE, warning=FALSE, fig.align='center' }
-plotRes(kinSum, id = kinSumIds[1]) 
+plotRes(kinSum, id = kinSumIds[1])
 ```
 
 
@@ -931,7 +931,7 @@ kinGroup <- kinshipGroupTest(fad, trait = tcancer,
 			     traitName = "cancer",
 			     nsim = nsim, strata = fad$sex)
 head(result(kinGroup))
- 
+
 ```
 
 The kinship group test finds a significant aggregation of cases in families 13,
@@ -953,7 +953,7 @@ resTab <- data.frame(total_families = length(unique(kinGroup$family)),
 			 kinGroupRes[kinGroupRes$kinship_padj < 0.05, "family"]
 		     ))
 		     )
-resTab 
+resTab
 ```
 
 The most significant kinship group identified by the kinship group test is shown
@@ -970,7 +970,7 @@ plot.
 ```{r  kingroup-3, mbreast-family-432-affecte-res-kinship, message=FALSE, warning=FALSE, fig.align='center' }
 plotPed(kinGroup, id = kinGroupRes[kinGroupRes$family == "432",
 				   "group_id"][1],
-	prune = TRUE, label1 = fr) 
+	prune = TRUE, label1 = fr)
 ```
 
 
@@ -989,7 +989,7 @@ significant enrichment of affected individuals in any family in the pedigree.
 binRes <- binomialTest(fad, trait = tcancer, traitName = "Cancer")
 
 binResTab <- result(binRes)
-head(binResTab) 
+head(binResTab)
 ```
 
 The probability used on the binomial test is shown in column `"prob"` and is in
@@ -1011,14 +1011,14 @@ tcancer[fad$sex == "M" | is.na(fad$sex)] <- NA
 binRes <- binomialTest(fad, trait = tcancer, prob = 1/8)
 
 binResTab <- result(binRes)
-head(binResTab) 
+head(binResTab)
 ```
 
 Below we plot the pedigree for the family with the strongest enrichment with
 affected individuals.
 
 ```{r  bintest-3, message = FALSE, fig.align = "center", fig.pos = "h!" }
-plotPed(binRes, family = 173) 
+plotPed(binRes, family = 173)
 ```
 
 


### PR DESCRIPTION
A new column `ksgrp` is added to the Kinship sum test, which groups affected individuals by kinship. Solves issue #15.

- [x]  `R CMD check` runs successfully.