### PR TITLE
Write HaploPainter files without backend installed

### DIFF
--- a/R/Methods-FAKinGroupResults.R
+++ b/R/Methods-FAKinGroupResults.R
@@ -404,6 +404,7 @@ setMethod("plotPed", "FAKinGroupResults", function(object, id=NULL,
     if(!any(names(affGroup) == id))
         stop("The id should be one of the names of the affected kinship ",
              "groups (i.e. names(affectedKinshipGroups(object)))!")
+    id <- as.character(id)
     affGroup <- affGroup[[id]]
     callNextMethod(object = object, id = id, family = family,
                    filename = filename, device = device,
@@ -419,6 +420,7 @@ setMethod("buildPed", "FAKinGroupResults",
               if (is.null(id))
                   stop("The id of the group has to be speficied!")
               affGroup <- affectedKinshipGroups(object)
+              id <- as.character(id)
               if (!any(names(affGroup) == id))
                   stop("The id should be one of the names of the affected ",
                        "kinship groups (i.e. ",
@@ -445,6 +447,7 @@ setMethod("shareKinship", "FAKinGroupResults",
     if (is.null(id))
         stop("The id of the group has to be speficied!")
     affGroup <- affectedKinshipGroups(object)
+    id <- as.character(id)
     if (!any(names(affGroup) == id))
         stop("The id should be one of the names of the affected kinship ",
              "groups (i.e. names(affectedKinshipGroups(object)))!")

--- a/R/plotting-functions.R
+++ b/R/plotting-functions.R
@@ -1,5 +1,5 @@
 ## here we define the pedigree plotting functions.
-switchPlotfun <- function(method){
+switchPlotfun <- function(method, check=TRUE){
     if(!missing(method)){
         method <- match.arg(method, c("ks2paint", "haplopaint"))
     }else{
@@ -9,7 +9,7 @@ switchPlotfun <- function(method){
             method <- "ks2paint"
         }
     }
-    if(method=="haplopaint"){
+    if(method=="haplopaint" && check){
         ## check if that is possible at all.
         method <- .checkHaplopaintRequirements()
     }
@@ -34,7 +34,7 @@ doPlotPed <- function(family=NULL, individual=NULL, father=NULL, mother=NULL,
     plotfun <- match.arg(plotfun, c("ks2paint", "haplopaint"))
     if(plotfun == "haplopaint"){
         if(device == "plot"){
-            device="pdf"
+            device <- "pdf"
             warning("haplopaint does not support device='plot', changing ",
                     "to 'pdf'.")
         }

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -7,6 +7,7 @@ o Keep memory consumption constant. This allows arbitrary long simulation
   of that problem, histograms and densities reported by the simulation
   functions may slightly deviate from comparable former runs on the same
   data.
+o Allow writing of HaploPainter input files without a HaploPainter installation.
 
 
 CHANGES in VERSION 1.19.1

--- a/inst/unitTests/test_FAData.R
+++ b/inst/unitTests/test_FAData.R
@@ -366,6 +366,12 @@ test_buildPed <- function() {
         plotPed(fad, id="4", device="plot")
         switchPlotfun()
     }
+    tmpf <- paste0(tempfile(), ".tsv")
+    switchPlotfun("haplopaint", check=FALSE)
+    plotPed(fad, id="4", device="txt")
+    switchPlotfun("ks2paint")
+    file.remove(tmpf)
+
     expect <- c(5, 26, 11, 12, 13)
     tmp <- buildPed(fad, id = c(26, 13, 12, 11), prune = TRUE)
     checkEquals(sort(tmp$id), sort(expect))

--- a/man/plotting-functions.Rd
+++ b/man/plotting-functions.Rd
@@ -19,7 +19,7 @@ doPlotPed(family=NULL, individual=NULL, father=NULL, mother=NULL, gender=NULL,
         text3.below.symbol=NULL, text4.below.symbol=NULL,
         filename=NULL, device="plot", res=600, ...)
 
-switchPlotfun(method)
+switchPlotfun(method, check=TRUE)
 
 }
 \arguments{
@@ -138,6 +138,14 @@ switchPlotfun(method)
     functions switches between the methods.
   }
 
+  \item{check}{
+    A logical indicating whether the plotting backends (currently
+    applied only to \code{HaploPaint}) is installed and working. Defaults
+    to \code{TRUE}, such that it is guaranteed that a call to
+    \code{doPlotPed} will at least technically succeed. The test is omitted
+    by setting this argument to \code{FALSE}.
+  }
+
   \item{...}{
     For \code{plotPed}: additional arguments submitted to the plotting
     function \code{doPlotPed}.
@@ -168,17 +176,23 @@ switchPlotfun(method)
   \code{HaploPainter} is a perl script/tool for pedigree plotting bundled in
   the package that requires however some dependencies that might not be
   present on every system. Thus, the package checks on startup whether
-  all requirements for \code{HaploPainter} are available.
+  all requirements for \code{HaploPainter} are available. This check can
+  be skipped by using \code{check=FALSE} when calling \code{switchPlotFun}.
+  While using this argument is generally not recommended, it is of use
+  when only writing \code{HaploPainter} input files, which does not make
+  use of the \code{HaploPainter} plotting backend.
 
   If \code{HaploPainter} is used, the plot can only be exported to a pdf
   or png device, while, if \code{kinship2} is used, the plot can also be
   directly plotted and displayed (if \code{device="plot"} is specified).
 
   \code{HaploPainter} plotting supports also \code{device = "txt"} in
-  which case the pedigree data is exported (in the HaploPainter file
+  which case the pedigree data are exported (in the HaploPainter file
   format) as a tabulator delimited file - no plot is created, the
-  name of the file is returned.
-  
+  name of the file is returned. This can even be done without a
+  \code{HaploPainter} executable by calling
+  \code{switchPlotFun("haplopaint", check=FALSE)}.
+
   Also, the arguments of this function match the arguments for
   \code{HaploPainter} and not all settings can be directly matched to
   settings in \code{kinship2} plotting. The list below lists all
@@ -252,7 +266,12 @@ switchPlotfun("ks2paint")
 doPlotPed(family=family$famid, individual=family$id, father=family$fatherid,
           mother=family$motherid, gender=family$sex, device="plot")
 
+## Finally, generate an input file that can be used for interactive or
+## scripted HaploPainter pedigree drawing.
+switchPlotfun("haplopaint", check=FALSE)
+doPlotPed(family=family$famid, individual=family$id, father=family$fatherid,
+          mother=family$motherid, gender=family$sex, device="txt",
+          filename="haplainter.tsv")
 
 }
 \keyword{hplot}
-

--- a/man/plotting-functions.Rd
+++ b/man/plotting-functions.Rd
@@ -121,10 +121,15 @@ switchPlotfun(method, check=TRUE)
   \item{device}{
     The format of the output file. Can be \code{"ps"}, \code{"pdf"},
     \code{"svg"}, \code{"png"} or \code{"txt"} if \code{HaploPainter} is
-    used to create the plot, or \code{"pdf"}, \code{"png"} or
-    \code{"plot"} if \code{kinship2} is used for plotting. Note: if
-    \code{"plot"} is specified the plot is displayed instead of exported
-    to a file.
+    used to create the plot, or \code{"pdf"}, \code{"png"} or \code{"plot"}
+    if \code{kinship2} is used for plotting. If the \code{HaploPainter}
+    backend is not installed, it is still possible to produce
+    \code{HaploPainter} input files using \code{devive = "txt"} for later
+    invocation of \code{HaploPainter}: this is achieved by calling
+    \code{switchPlotfun("haplopaint", check = FALSE)}, which will not check
+    for the presence of a \code{HaploPainter} executable. Note: if
+    \code{"plot"} is specified the plot is displayed instead of exported to
+    a file.
   }
 
   \item{res}{
@@ -271,7 +276,7 @@ doPlotPed(family=family$famid, individual=family$id, father=family$fatherid,
 switchPlotfun("haplopaint", check=FALSE)
 doPlotPed(family=family$famid, individual=family$id, father=family$fatherid,
           mother=family$motherid, gender=family$sex, device="txt",
-          filename="haplainter.tsv")
+          filename="haplopainter.tsv")
 
 }
 \keyword{hplot}


### PR DESCRIPTION
Instead of implementing a new function `writeHaplopainterFile` as suggested by @jorainer, I opted to interfere as little as possible with the source code. Everything else looked like code or at least interface duplication, something I am not very happy with. There is simply an option in `switchPlotFun` that allows to skip the `HaploPainter` installation check. It still defaults to the previous behavior and will not break existing code.

- [x] `R CMD check` successful for R-4.1.0 BioC 3.13.
- [x] Updated documentation.
- [x] Updated unit tests.

Fixes issue #23.